### PR TITLE
Ignore .python-version from pyenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 dist
 *.txt
 .mypy_cache
+.python-version


### PR DESCRIPTION
`pyenv local 3.6.9` drops a `.python-version` file so that it knows what versions are active in that directory.  Add that file to the ignore list.