### PR TITLE
Add reuse to dep not-a-resolver

### DIFF
--- a/honesty/tests/deps.py
+++ b/honesty/tests/deps.py
@@ -104,6 +104,44 @@ class FindCompatibleVersionTest(unittest.TestCase):
         v = _find_compatible_version(FOO_PACKAGE, SpecifierSet(""), four)
         self.assertEqual(v1, v)
 
+    def test_respect_already_chosen(self) -> None:
+        three = Version("3.7.5")
+        # This returns v1 with no already_chosen
+        v = _find_compatible_version(
+            FOO_PACKAGE, SpecifierSet(""), three, already_chosen={"foo": Version("2.0")}
+        )
+        self.assertEqual(v2, v)
+
+    def test_current_version_callback(self) -> None:
+        three = Version("3.7.5")
+
+        def current_version(p: str) -> str:
+            return "2.0"
+
+        # This would normally find v1 ("1.0") on its own
+        v = _find_compatible_version(
+            FOO_PACKAGE,
+            SpecifierSet(""),
+            three,
+            current_versions_callback=current_version,
+        )
+        self.assertEqual(Version("2.0"), v)
+
+    def test_current_version_callback_nonpublic(self) -> None:
+        three = Version("3.7.5")
+
+        def current_version(p: str) -> str:
+            return "2.99"
+
+        # This would normally find v1 ("1.0") on its own
+        v = _find_compatible_version(
+            FOO_PACKAGE,
+            SpecifierSet(""),
+            three,
+            current_versions_callback=current_version,
+        )
+        self.assertEqual(Version("2.99"), v)
+
 
 class TestSeekableHttpFile(unittest.TestCase):
     def test_live(self) -> None:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ black==20.8b1
 coverage==5.5
 flake8==3.9.1
 usort==0.6.4
-ufmt==1.2.
+ufmt==1.2.1
 mypy==0.812
 pessimist==0.9.0
 tox==3.23.0


### PR DESCRIPTION
This has two pieces that work in conjunction:

1. Whenever picking versions, if we've already chosen one during this
   call to `walk()` then prioritize keeping that.
2. If we need to pick a version greenfield, prioritize keeping the
   version we currently have, if any, otherwise choose the newest.

You can try this out in the CLI by passing e.g. `--have numpy==1.19.0`.

If no. 1 above is impossible, it will output a message and keep going.
Only a couple of real-world examples I've seen trigger this behavior,
including https://gist.github.com/thatch/9c0e076f96569067851fbf8c43d39c53
(but not fixing the edge that shows line 5, after being revised for line
20, is a bug).

If you pass a non-public version which can be used in no. 2, it will be
displayed as no-sdist no-wheel which is incorrect (it probably deserves
a third flag for "reused" or so, which would be useful to set even for
public versions).  This section of the code needs a rewrite.

Versions reused from no. 2 will not have deps listed, initially because
non-public versions don't have easily-accessible deps, but also for
consistency and probably not needing them (if this is being used to
determine what new needs to be installed).